### PR TITLE
Fix "Match the opening parameters brace"

### DIFF
--- a/grammars/gmod-lua.ag.cson
+++ b/grammars/gmod-lua.ag.cson
@@ -77,7 +77,7 @@ patterns: [
 			)?
 
 			# Match the opening parameters brace
-		
+			\\(
 """
 		beginCaptures:
 			1: name: "keyword.control.lua"


### PR DESCRIPTION
It appears this was left out and overlooked.